### PR TITLE
feat: changed padding to scale

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
   const {
     settings,
     setAspectRatio,
-    setPadding,
+    setScale,
     setInsetColor,
     setInsetPadding,
     setBackgroundColor,
@@ -38,11 +38,10 @@ export default function Home() {
                 <div
                   ref={clipboardRef}
                   style={{
-                    padding: `${settings.padding}%`,
+                    padding: `4%`,
                   }}
                   className={`${cn(
                     "max-w-6xl max-h-[648px] grid place-items-center",
-                    settings.padding === 0 && "[&>img]:rounded-none",
                     settings.aspectRatio,
                     settings.aspectRatio === "aspect-[3/4]" && "h-fit",
                     settings.aspectRatio === "aspect-video" && "w-full",
@@ -51,6 +50,7 @@ export default function Home() {
                 >
                   <ClipboardImage
                     insetColor={settings.insetColor}
+                    scale={settings.scale}
                     insetPadding={settings.insetPadding}
                     setInsetColor={setInsetColor}
                     setInsetPadding={setInsetPadding}
@@ -73,7 +73,7 @@ export default function Home() {
                 <Settings
                   settings={settings}
                   setAspectRatio={setAspectRatio}
-                  setPadding={setPadding}
+                  setScale={setScale}
                   setInsetColor={setInsetColor}
                   setInsetPadding={setInsetPadding}
                   setBackgroundColor={setBackgroundColor}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,11 +39,8 @@ export default function Home() {
               <div className="grid w-full place-items-center rounded-md bg-[#020617] bg-[length:15px_15px] p-12 [background-image:radial-gradient(#64748b_0.75px,_transparent_0)]">
                 <div
                   ref={clipboardRef}
-                  style={{
-                    overflow:"hidden"
-                  }}
                   className={`${cn(
-                    "max-w-6xl max-h-[648px] grid place-items-center p-[4%]",
+                    "max-w-6xl max-h-[648px] grid place-items-center p-[4%] overflow-hidden",
                     settings.aspectRatio,
                     settings.aspectRatio === "aspect-[3/4]" && "h-fit",
                     settings.aspectRatio === "aspect-video" && "w-full",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,8 @@ export default function Home() {
     settings,
     setAspectRatio,
     setScale,
+    setPositionX,
+    setPositionY,
     setInsetColor,
     setInsetPadding,
     setBackgroundColor,
@@ -38,10 +40,10 @@ export default function Home() {
                 <div
                   ref={clipboardRef}
                   style={{
-                    padding: `4%`,
+                    overflow:"hidden"
                   }}
                   className={`${cn(
-                    "max-w-6xl max-h-[648px] grid place-items-center",
+                    "max-w-6xl max-h-[648px] grid place-items-center p-[4%]",
                     settings.aspectRatio,
                     settings.aspectRatio === "aspect-[3/4]" && "h-fit",
                     settings.aspectRatio === "aspect-video" && "w-full",
@@ -51,6 +53,8 @@ export default function Home() {
                   <ClipboardImage
                     insetColor={settings.insetColor}
                     scale={settings.scale}
+                    positionX={settings.positionX}
+                    positionY={settings.positionY}
                     insetPadding={settings.insetPadding}
                     setInsetColor={setInsetColor}
                     setInsetPadding={setInsetPadding}
@@ -74,6 +78,8 @@ export default function Home() {
                   settings={settings}
                   setAspectRatio={setAspectRatio}
                   setScale={setScale}
+                  setPositionX={setPositionX}
+                  setPositionY={setPositionY}
                   setInsetColor={setInsetColor}
                   setInsetPadding={setInsetPadding}
                   setBackgroundColor={setBackgroundColor}

--- a/src/components/ClipboardImage.tsx
+++ b/src/components/ClipboardImage.tsx
@@ -9,11 +9,13 @@ import { suggestedSettings } from "@config/defaults";
 
 export const ClipboardImage = ({
   insetColor,
+  scale,
   insetPadding,
   setInsetColor,
   setInsetPadding,
 }: {
   insetColor: string;
+  scale: number;
   insetPadding: number;
   setInsetColor: (input: string) => void;
   setInsetPadding: (input: number) => void;
@@ -77,6 +79,7 @@ export const ClipboardImage = ({
       style={{
         padding: `${insetPadding}%`,
         background: insetPadding ? insetColor : "transparent",
+        scale: `${(scale)/100}`
       }}
     />
   );

--- a/src/components/ClipboardImage.tsx
+++ b/src/components/ClipboardImage.tsx
@@ -10,12 +10,16 @@ import { suggestedSettings } from "@config/defaults";
 export const ClipboardImage = ({
   insetColor,
   scale,
+  positionX,
+  positionY,
   insetPadding,
   setInsetColor,
   setInsetPadding,
 }: {
   insetColor: string;
-  scale: number;
+  scale: number,
+  positionX: number,
+  positionY: number,
   insetPadding: number;
   setInsetColor: (input: string) => void;
   setInsetPadding: (input: number) => void;
@@ -79,7 +83,8 @@ export const ClipboardImage = ({
       style={{
         padding: `${insetPadding}%`,
         background: insetPadding ? insetColor : "transparent",
-        scale: `${(scale)/100}`
+        scale: `${(scale)/100}`,
+        transform: `translate(${positionX}%, ${positionY}%)`
       }}
     />
   );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -56,6 +56,8 @@ export const Settings = ({
   settings,
   setAspectRatio,
   setScale,
+  setPositionX,
+  setPositionY,
   setInsetColor,
   setInsetPadding,
   setBackgroundColor,
@@ -63,13 +65,16 @@ export const Settings = ({
   settings: SettingsType;
   setAspectRatio: (v: SettingsType["aspectRatio"]) => void;
   setScale: (v: SettingsType["scale"]) => void;
+  setPositionX: (v: SettingsType["positionX"]) => void;
+  setPositionY: (v: SettingsType["positionY"]) => void;
   setInsetColor: (v: SettingsType["insetColor"]) => void;
   setInsetPadding: (v: SettingsType["insetPadding"]) => void;
   setBackgroundColor: (v: SettingsType["backgroundColor"]) => void;
 }) => {
   const handleReset = () => {
     setAspectRatio(defaultSettings.aspectRatio);
-    setScale(defaultSettings.scale);
+    setPositionX(defaultSettings.positionX);
+    setPositionY(defaultSettings.positionY);
     setInsetPadding(suggestedSettings.insetPadding);
   };
 
@@ -161,9 +166,9 @@ export const Settings = ({
       </div>
       <div>
         <Label htmlFor="scale">
-          <span>Scale</span>{" "}
+          <span>Scale and position</span>{" "}
           <Tooltip
-            content={<p>The scale of the image</p>}
+            content={<p>The scale and position of the image</p>}
             side="top"
           >
             <Info className="h-4 w-4 cursor-help stroke-slate-200/90" />
@@ -191,6 +196,26 @@ export const Settings = ({
               value = value < 50 ? 50 : value;
               setScale(value);
             }}
+          />
+        </div>
+        <div className="flex items-center gap-x-2">
+          <p>X</p>
+          <Slider
+            onValueChange={(value) => setPositionX(value[0])}
+            value={[settings.positionX]}
+            max={50}
+            min={-50}
+            step={1}
+          />
+        </div>
+        <div className="flex items-center gap-x-2">
+          <p>Y</p>
+          <Slider
+            onValueChange={(value) => setPositionY(-value[0])}
+            value={[-settings.positionY]}
+            max={50}
+            min={-50}
+            step={1}
           />
         </div>
       </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -73,6 +73,7 @@ export const Settings = ({
 }) => {
   const handleReset = () => {
     setAspectRatio(defaultSettings.aspectRatio);
+    setScale(defaultSettings.scale);
     setPositionX(defaultSettings.positionX);
     setPositionY(defaultSettings.positionY);
     setInsetPadding(suggestedSettings.insetPadding);
@@ -174,7 +175,7 @@ export const Settings = ({
             <Info className="h-4 w-4 cursor-help stroke-slate-200/90" />
           </Tooltip>
         </Label>
-        <div className="flex items-center gap-x-2">
+        <div className="flex items-center gap-x-2 mb-2">
           <Slider
             id="scale"
             onValueChange={(value) => setScale(value[0])}
@@ -198,25 +199,54 @@ export const Settings = ({
             }}
           />
         </div>
-        <div className="flex items-center gap-x-2">
+        <div className="flex items-center gap-x-2 mb-2">
           <Label htmlFor="slider-position-x">X</Label>
           <Slider
-          id="slider-position-x"
+            id="slider-position-x"
             onValueChange={(value) => setPositionX(value[0])}
             value={[settings.positionX]}
             max={100}
             min={-100}
             step={1}
           />
+          <Input
+            className="w-20"
+            type="number"
+            placeholder="0"
+            min={-100}
+            max={100}
+            value={settings.positionX}
+            onChange={(e) => {
+              let value = parseInt(e.target.value);
+              value = value > 100 ? 100 : value;
+              value = value < -100 ? -100 : value;
+              setPositionX(value);
+            }}
+          />
         </div>
         <div className="flex items-center gap-x-2">
-          <p>Y</p>
+          <Label htmlFor="slider-position-y">Y</Label>
           <Slider
+            id="slider-position-y"
             onValueChange={(value) => setPositionY(-value[0])}
             value={[-settings.positionY]}
-            max={50}
-            min={-50}
+            max={100}
+            min={-100}
             step={1}
+          />
+          <Input
+            className="w-20"
+            type="number"
+            placeholder="0"
+            min={-100}
+            max={100}
+            value={settings.positionY}
+            onChange={(e) => {
+              let value = parseInt(e.target.value);
+              value = value > 100 ? 100 : value;
+              value = value < -100 ? -100 : value;
+              setPositionY(value);
+            }}
           />
         </div>
       </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -55,21 +55,21 @@ const backgroundColors = [
 export const Settings = ({
   settings,
   setAspectRatio,
-  setPadding,
+  setScale,
   setInsetColor,
   setInsetPadding,
   setBackgroundColor,
 }: {
   settings: SettingsType;
   setAspectRatio: (v: SettingsType["aspectRatio"]) => void;
-  setPadding: (v: SettingsType["padding"]) => void;
+  setScale: (v: SettingsType["scale"]) => void;
   setInsetColor: (v: SettingsType["insetColor"]) => void;
   setInsetPadding: (v: SettingsType["insetPadding"]) => void;
   setBackgroundColor: (v: SettingsType["backgroundColor"]) => void;
 }) => {
   const handleReset = () => {
     setAspectRatio(defaultSettings.aspectRatio);
-    setPadding(defaultSettings.padding);
+    setScale(defaultSettings.scale);
     setInsetPadding(suggestedSettings.insetPadding);
   };
 
@@ -160,10 +160,10 @@ export const Settings = ({
         </RadioGroup>
       </div>
       <div>
-        <Label htmlFor="padding">
-          <span>Padding</span>{" "}
+        <Label htmlFor="scale">
+          <span>Scale</span>{" "}
           <Tooltip
-            content={<p>Space between the image and frame</p>}
+            content={<p>The scale of the image</p>}
             side="top"
           >
             <Info className="h-4 w-4 cursor-help stroke-slate-200/90" />
@@ -171,24 +171,23 @@ export const Settings = ({
         </Label>
         <div className="flex items-center gap-x-2">
           <Slider
-            id="padding"
-            onValueChange={(value) => setPadding(value[0])}
-            value={[settings.padding]}
-            max={10}
+            id="scale"
+            onValueChange={(value) => setScale(value[0])}
+            value={[settings.scale]}
+            max={150}
+            min={50}
             step={1}
           />
           <Input
             className="w-16"
             type="number"
             placeholder="4"
-            min={0}
-            max={10}
-            value={settings.padding}
+            min={50}
+            max={150}
+            value={settings.scale}
             onChange={(e) => {
               let value = parseInt(e.target.value);
-              value = value > 10 ? 10 : value;
-              value = value < 0 ? 0 : value;
-              setPadding(value);
+              setScale(value);
             }}
           />
         </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -201,10 +201,11 @@ export const Settings = ({
         <div className="flex items-center gap-x-2">
           <Label htmlFor="slider-position-x">X</Label>
           <Slider
+          id="slider-position-x"
             onValueChange={(value) => setPositionX(value[0])}
             value={[settings.positionX]}
-            max={50}
-            min={-50}
+            max={100}
+            min={-100}
             step={1}
           />
         </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -181,12 +181,14 @@ export const Settings = ({
           <Input
             className="w-16"
             type="number"
-            placeholder="4"
+            placeholder="100"
             min={50}
             max={150}
             value={settings.scale}
             onChange={(e) => {
               let value = parseInt(e.target.value);
+              value = value > 150 ? 150 : value;
+              value = value < 50 ? 50 : value;
               setScale(value);
             }}
           />

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -199,7 +199,7 @@ export const Settings = ({
           />
         </div>
         <div className="flex items-center gap-x-2">
-          <p>X</p>
+          <Label htmlFor="slider-position-x">X</Label>
           <Slider
             onValueChange={(value) => setPositionX(value[0])}
             value={[settings.positionX]}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -10,6 +10,8 @@ export type AspectRatio =
 export type Settings = {
   aspectRatio: AspectRatio;
   scale: number;
+  positionX: number;
+  positionY:number;
   insetColor: string;
   insetPadding: number;
   backgroundColor: string;
@@ -18,6 +20,8 @@ export type Settings = {
 export const defaultSettings: Settings = {
   aspectRatio: "aspect-video",
   scale: 100,
+  positionX: 0,
+  positionY: 0,
   insetColor: "#000000",
   insetPadding: 0,
   backgroundColor:

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -9,7 +9,7 @@ export type AspectRatio =
 
 export type Settings = {
   aspectRatio: AspectRatio;
-  padding: number;
+  scale: number;
   insetColor: string;
   insetPadding: number;
   backgroundColor: string;
@@ -17,7 +17,7 @@ export type Settings = {
 
 export const defaultSettings: Settings = {
   aspectRatio: "aspect-video",
-  padding: 4,
+  scale: 100,
   insetColor: "#000000",
   insetPadding: 0,
   backgroundColor:

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -7,8 +7,8 @@ type SettingActions =
       value: Settings["aspectRatio"];
     }
   | {
-      type: "SET_PADDING";
-      value: Settings["padding"];
+      type: "SET_SCALE";
+      value: Settings["scale"];
     }
   | {
       type: "SET_INSET_COLOR";
@@ -33,10 +33,10 @@ const settingsReducer = (
         ...prevState,
         aspectRatio: value,
       };
-    case "SET_PADDING":
+    case "SET_SCALE":
       return {
         ...prevState,
-        padding: value,
+        scale: value,
       };
     case "SET_INSET_COLOR":
       return {
@@ -66,8 +66,8 @@ export const useSettings = (defaultSettings: Settings) => {
     settings,
     setAspectRatio: (value: Settings["aspectRatio"]) =>
       dispatch({ type: "SET_ASPECT_RATIO", value }),
-    setPadding: (value: Settings["padding"]) =>
-      dispatch({ type: "SET_PADDING", value }),
+    setScale: (value: Settings["scale"]) =>
+      dispatch({ type: "SET_SCALE", value }),
     setInsetColor: (value: Settings["insetColor"]) =>
       dispatch({ type: "SET_INSET_COLOR", value }),
     setInsetPadding: (value: Settings["insetPadding"]) =>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -6,9 +6,18 @@ type SettingActions =
       type: "SET_ASPECT_RATIO";
       value: Settings["aspectRatio"];
     }
-  | {
+  |
+    {
       type: "SET_SCALE";
       value: Settings["scale"];
+    }
+  | {
+      type: "SET_POSITIONX";
+      value: Settings["positionX"];
+    }
+  | {
+    type: "SET_POSITIONY";
+    value: Settings["positionY"];
     }
   | {
       type: "SET_INSET_COLOR";
@@ -37,6 +46,16 @@ const settingsReducer = (
       return {
         ...prevState,
         scale: value,
+      };
+    case "SET_POSITIONX":
+      return {
+        ...prevState,
+        positionX: value,
+      };
+    case "SET_POSITIONY":
+      return {
+        ...prevState,
+        positionY: value,
       };
     case "SET_INSET_COLOR":
       return {
@@ -68,6 +87,10 @@ export const useSettings = (defaultSettings: Settings) => {
       dispatch({ type: "SET_ASPECT_RATIO", value }),
     setScale: (value: Settings["scale"]) =>
       dispatch({ type: "SET_SCALE", value }),
+    setPositionX: (value: Settings["positionX"]) =>
+      dispatch({ type: "SET_POSITIONX", value }),
+    setPositionY: (value: Settings["positionY"]) =>
+      dispatch({ type: "SET_POSITIONY", value }),
     setInsetColor: (value: Settings["insetColor"]) =>
       dispatch({ type: "SET_INSET_COLOR", value }),
     setInsetPadding: (value: Settings["insetPadding"]) =>


### PR DESCRIPTION
fixes #57

What I have done:

1. Renamed variables, functions, types and so on from "padding" to "scale"
2. Set a constant padding of 4% to the parent-element of `ClipBoardImage` in _page.tsx_
3. In _ClipBoardImage.tsx_ adapted the slider and input
4. In the `Image` element, within its `style`, added a scale css-property